### PR TITLE
[Update] Fix trusted-nodes.json for Raft rejoining

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -307,7 +307,8 @@ func (pm *ProtocolManager) newPeer(pv int, p *p2p.Peer, rw p2p.MsgReadWriter) *p
 // handle is the callback invoked to manage the life cycle of an eth peer. When
 // this function terminates, the peer is disconnected.
 func (pm *ProtocolManager) handle(p *peer) error {
-	if pm.peers.Len() >= pm.maxPeers {
+	/// Allow a peer in trusted-nodes.json when the number of peers is MAX
+	if !p.Peer.IsTrusted() && pm.peers.Len() >= pm.maxPeers {
 		return p2p.DiscTooManyPeers
 	}
 	p.Log().Debug("Ethereum peer connected", "name", p.Name())

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -460,3 +460,8 @@ func (p *Peer) Info() *PeerInfo {
 	}
 	return info
 }
+
+/// Check whether a peer is in trusted-nodes.json or not
+func (p *Peer) IsTrusted() bool {
+	return p.rw.is(trustedConn)
+}

--- a/pre_built/Ubuntu/README.md
+++ b/pre_built/Ubuntu/README.md
@@ -4,4 +4,4 @@ go version go1.9.2 linux/amd64
 MD5
 - 9830c6109d180612e18f78310269486b  bootnode
 
-- 0e62c94e5651eca6d3c83faf14b0bbe6  geth
+- 3b3723f54b6a96e0fef3db81497fb303  geth


### PR DESCRIPTION
Fixing for `trusted-node.json` in Eth Handler for Raft rejoining.
The change for `trusted-node.json` usage will put in `go-halo-script`