### PR TITLE
[PATCH] Relese for Raft rejoining and disable PrivateSend

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 2         // Major version component of the current release
 	VersionMinor = 0         // Minor version component of the current release
-	VersionPatch = 1         // Patch version component of the current release
+	VersionPatch = 2         // Patch version component of the current release
 	VersionMeta  = "release" // Version metadata to append to the version string
 
 	QuorumVersionMajor = 2

--- a/pre_built/Ubuntu/README.md
+++ b/pre_built/Ubuntu/README.md
@@ -4,4 +4,4 @@ go version go1.9.2 linux/amd64
 MD5
 - 9830c6109d180612e18f78310269486b  bootnode
 
-- bd1ef3ac9c15bbde59256e3d6ffbd924  geth
+- f829ba07a59bf451bdb94fd598c0e0f5  geth


### PR DESCRIPTION
Update binary and increase the patch version number: 2.0.2