### PR TITLE
[FIX] Race condition in TxReplay when using TxPool.validateTx() function

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -196,9 +196,6 @@ func (self *StateDB) GetBalance(addr common.Address) *big.Int {
 }
 
 func (self *StateDB) GetNonce(addr common.Address) uint64 {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
 	stateObject := self.getStateObject(addr)
 	if stateObject != nil {
 		return stateObject.Nonce()

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1171,8 +1171,8 @@ func (pool *TxPool) demoteUnexecutables() {
 
 /// With remote txn on full-MN, we need to replay it to other peers only.
 func (pool *TxPool) ReplayRemoteTx(txs []*types.Transaction) {
-	pool.mu.RLock()
-	defer pool.mu.RUnlock()
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
 
 	/// Ignore a known txn (it's local txn with going back from other nodes)
 	for _, tx := range txs {


### PR DESCRIPTION
1. Reason
- `TxPool.ReplayRemoteTx()` used `TxPool.validateTx()` to validate a transaction before replaying. The function does a change in StateDB object when `GetNonce()` or `GetBalance()` of an address.
- However, the new function `TxPool.ReplayRemoteTx()` only use READER locking.

2. Solution
- Change to WRITER locking.