### PR TITLE
[fix] Always checking the intrinsic gas of transaction

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -637,7 +637,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return err
 	}
-	if !isQuorum && tx.Gas() < intrGas {
+	if tx.Gas() < intrGas {
 		return ErrIntrinsicGas
 	}
 	return nil


### PR DESCRIPTION
connect haloplatform/hpm#1486

1. Description
- Always checking the intrinsic gas of transaction when validating a txn in `TxPool`