### PR TITLE
Raft bug in starting and stopping

### DIFF
--- a/raft/backend.go
+++ b/raft/backend.go
@@ -83,7 +83,7 @@ func (service *RaftService) APIs() []rpc.API {
 // Start implements node.Service, starting the background data propagation thread
 // of the protocol.
 func (service *RaftService) Start(p2pServer *p2p.Server) error {
-	service.raftProtocolManager.Start(p2pServer)
+	go service.raftProtocolManager.Start(p2pServer)
 	return nil
 }
 

--- a/raft/backend.go
+++ b/raft/backend.go
@@ -95,7 +95,7 @@ func (service *RaftService) Stop() error {
 	service.minter.stop()
 	service.eventMux.Stop()
 
-	service.chainDb.Close()
+	/// Don't close chainDb because EthereumService already did it.
 
 	log.Info("Raft stopped")
 	return nil


### PR DESCRIPTION
1. Detail
a) Raft is crashed when starting if RaftService is starting first in `node` module.
https://github.com/haloplatform/hpm/issues/909
b) RaftService: Duplicate `chainDB` closing.
https://github.com/haloplatform/hpm/issues/1520
(See detail in Waffle board)
